### PR TITLE
Replace clone with init, add update, merge clean into link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,13 @@ jobs:
       matrix:
         command:
           - help
-          - clone
+          - init
+          - update
           - link
           - install-brew
           - install-defaults
           - install-fisher
           - install-vim
-          - clean
 
     steps:
       - uses: actions/checkout@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,23 +6,23 @@ Automated macOS environment as code. Dotfiles are symlinked into place; nothing 
 
 `dot.sh` (zsh) is the single entry point for all setup tasks:
 
-| Command             | What it does                                            |
-|---------------------|-------------------------------------------------------- |
-| `clone`             | Clones this repo to `~/src/github.com/arbourd/dotfiles` |
-| `link`              | Symlinks all dotfiles into `~`                          |
-| `install`           | Runs brew + defaults + fisher + vim in order            |
-| `install-brew`      | Installs/updates Homebrew packages from Brewfile        |
-| `install-defaults`  | Applies macOS `defaults write` settings                 |
-| `install-fisher`    | Installs/updates Fisher and fish plugins                |
-| `install-vim`       | Installs/updates vim-plug and Vim plugins               |
-| `clean`             | Removes stale dotfile symlinks                          |
+| Command             | What it does                                                                    |
+|---------------------|---------------------------------------------------------------------------------|
+| `init`              | Clones this repo to `~/src/github.com/arbourd/dotfiles` and symlinks `dot.sh` to `~/.local/bin/dot` |
+| `update`            | Pulls latest changes and reports the version and whether it was updated         |
+| `link`              | Symlinks all dotfiles into `~` and removes stale symlinks                       |
+| `install`           | Runs brew + defaults + fisher + vim in order                                    |
+| `install-brew`      | Installs/updates Homebrew packages from Brewfile                                |
+| `install-defaults`  | Applies macOS `defaults write` settings                                         |
+| `install-fisher`    | Installs/updates Fisher and fish plugins                                        |
+| `install-vim`       | Installs/updates vim-plug and Vim plugins                                       |
 
-On a new machine, run commands in this order: `clone` → `link` → `install`. `link` must run before `install` because the install steps (fisher, vim) depend on config files already being in place at their expected locations.
+On a new machine, run commands in this order: `init` → `link` → `install`. `link` must run before `install` because the install steps (fisher, vim) depend on config files already being in place at their expected locations.
 
 ## Repository layout
 
 ```
-dot.sh      # entry point — clone/link/install subcommands
+dot.sh      # entry point — init/update/link/install subcommands
 .macOS      # zsh script that applies macOS defaults write settings
 Brewfile    # Homebrew formulae, casks, and Mac App Store apps
 agents      # global AI agent persona and skill definitions
@@ -57,20 +57,30 @@ Individual symlinks are used to allow personal, non-repo agents and skills to co
 
 Primary shell is **fish** (`/opt/homebrew/bin/fish`). `sh/.shrc` is a POSIX-compatible fallback used for bash and zsh. `dot.sh` is zsh to maintain compatibility with macOS.
 
-Private/sensitive env vars go in `~/.config/fish/private.fish` (not tracked; created empty by `_pre`). Git private config goes in `~/.config/git/private` (not tracked; included via `git/config`).
+Private/sensitive env vars go in `~/.config/fish/private.fish` (not tracked; created empty by `_ensure`). Git private config goes in `~/.config/git/private` (not tracked; included via `git/config`).
 
 ## Homebrew
 
 Packages are in `Brewfile`. Run with `HOMEBREW_BUNDLE_NO_LOCK=1` — no `Brewfile.lock.json` is generated or committed.
 
+## Adding or removing a command
+
+When a `dot.sh` command is added, renamed, or removed, update all five of these in the same change:
+
+1. `dot.sh` — `_usage()` and the `case` statement
+2. `README.md` — usage block in Installation
+3. `AGENTS.md` — command table and repo layout comment
+4. `.github/workflows/ci.yml` — `matrix.command` list
+5. `tests/dot.zunit` — add or remove the corresponding test(s)
+
 ## CI
 
-GitHub Actions (`.github/workflows/ci.yml`) runs each `dot.sh` command as a matrix job on `macos-latest`. MAS installs are skipped in CI via `HOMEBREW_BUNDLE_MAS_SKIP`. Dependabot keeps Actions up to date daily.
+GitHub Actions (`.github/workflows/ci.yml`) runs each `dot.sh` command as a matrix job on `macos-latest`, plus a separate job that runs the zunit test suite on `ubuntu-latest`. MAS installs are skipped in CI via `HOMEBREW_BUNDLE_MAS_SKIP`. Dependabot keeps Actions up to date daily.
 
 ## Adding a new dotfile
 
 1. Add the config file under an appropriately named directory.
-2. Add a `mkdir -p` for its target directory in `_pre` if needed.
+2. Add an `_ensure` call for its target directory in `_link` if needed.
 3. Add an `ln -vsf` line in `_link` pointing it to its target path.
 4. If it requires a new package, add it to `Brewfile`.
 

--- a/README.md
+++ b/README.md
@@ -7,20 +7,21 @@ Automated environment as code.
   1. Install with script
 
       ```console
-      $ curl -sSL https://raw.githubusercontent.com/arbourd/dotfiles/main/dot.sh | sh -s -- clone
+      $ curl -sSL https://raw.githubusercontent.com/arbourd/dotfiles/main/dot.sh | zsh -s -- init
       ```
 
-  1. Run `dot.sh`
+  1. Run `dot`
 
       ```console
-      $ ./dot.sh
-      Usage: ./dot.sh [COMMAND]
+      $ dot
+      Usage: dot [COMMAND]
       Commands:
         help              prints this dialog
-        clone             clones dotfiles to GETPATH (~/src)
-        link              symlinks dotfiles
-        install           installs all packages
+        init              clones dotfiles to GETPATH (~/src) and symlinks dot.sh to ~/.local/bin
+        update            updates the dotfiles repository
+        link              symlinks dotfiles and removes stale symlinks
 
+        install           installs all packages
         install-defaults  installs macos defaults
         install-brew      installs homebrew packages
         install-fisher    installs fisher packages

--- a/dot.sh
+++ b/dot.sh
@@ -8,8 +8,10 @@ if [ -z "$getpath" ]; then
     getpath=$(git config --global get.path || echo "")
 fi
 if [ -z "$getpath" ]; then
-    getpath="~/src"
+    getpath=~/src
 fi
+# git config and env vars return "~/src" as a literal string, so expand ~ manually
+getpath="${getpath/#\~/$HOME}"
 
 _log() {
     echo "\n$(tput bold)$*$(tput sgr0)\n"
@@ -56,12 +58,12 @@ _clean_dir() {
 }
 
 _usage() {
-    echo "Usage: ./dot.sh [COMMAND]
+    echo "Usage: dot [COMMAND]
 Commands:
   help              prints this dialog
-  clone             clones dotfiles to GETPATH (${getpath})
-  link              symlinks dotfiles
-  clean             removes stale dotfile symlinks
+  init              clones dotfiles to GETPATH (${getpath}) and symlinks dot.sh to ~/.local/bin
+  update            updates the dotfiles repository
+  link              symlinks dotfiles and removes stale symlinks
 
   install           installs all packages
   install-defaults  installs macos defaults
@@ -72,11 +74,11 @@ Commands:
 "
 }
 
-_clone() {
+_init() {
     _require git
-    local target="$getpath/github.com/arbourd/dotfiles"
+    local target="${${getpath%/}/#\~/$HOME}/github.com/arbourd/dotfiles"
 
-    _log "Cloning dotfiles to $target"
+    _log "Initializing dotfiles to $target"
 
     if [ -d "$target" ]; then
         echo "Directory already exists. Pulling latest changes..."
@@ -86,7 +88,24 @@ _clone() {
         git clone https://github.com/arbourd/dotfiles.git "$target"
     fi
 
-    _log "$target"
+    _log "Symlinking dot.sh to ~/.local/bin/dot"
+    _ensure ~/.local/bin/
+    ln -vsf "$target/dot.sh" ~/.local/bin/dot
+}
+
+_update() {
+    _require git
+
+    local before after
+    before=$(git -C "$DIR" rev-parse --short HEAD)
+    git -C "$DIR" pull --quiet
+    after=$(git -C "$DIR" rev-parse --short HEAD)
+
+    if [ "$before" = "$after" ]; then
+        echo "dotfiles $after (up to date)"
+    else
+        echo "dotfiles updated $before -> $after"
+    fi
 }
 
 _link() {
@@ -127,6 +146,8 @@ _link() {
 
     _log "Symlinking agent dotfiles"
     _link_agents
+
+    _clean
 }
 
 _link_agents() {
@@ -218,8 +239,11 @@ _install() {
 }
 
 case $1 in
-    clone)
-        _clone
+    init)
+        _init
+        ;;
+    update)
+        _update
         ;;
     link)
         _link
@@ -238,9 +262,6 @@ case $1 in
         ;;
     install-vim)
         _install_vim
-        ;;
-    clean)
-        _clean
         ;;
     help)
         _usage

--- a/sh/.shrc
+++ b/sh/.shrc
@@ -1,6 +1,7 @@
 ## Exports
 #
 export EDITOR=vim
+export PATH=$HOME/.local/bin:$PATH
 export PATH=$HOME/go/bin:$PATH
 export PATH=$HOME/.cargo/bin:$PATH
 

--- a/sh/config.fish
+++ b/sh/config.fish
@@ -5,6 +5,7 @@ set fish_greeting ""
 #
 set -x SHELL /opt/homebrew/bin/fish
 set -x EDITOR vim
+set -x PATH $HOME/.local/bin $PATH
 set -x PATH $HOME/go/bin $PATH
 set -x PATH $HOME/.cargo/bin $PATH
 

--- a/tests/dot.zunit
+++ b/tests/dot.zunit
@@ -44,19 +44,22 @@
     assert $state equals 0
 }
 
-@test 'clone creates parent dirs and clones when target missing' {
+@test 'init creates parent dirs, clones, and symlinks dot when target missing' {
     getpath="$FAKE_HOME/src"
+    local target="$FAKE_HOME/src/github.com/arbourd/dotfiles"
 
     local git_args
     git() { git_args="$*"; }
 
-    _clone > /dev/null
+    _init > /dev/null
 
     assert "$FAKE_HOME/src/github.com/arbourd" is_dir
-    assert "$git_args" same_as "clone https://github.com/arbourd/dotfiles.git $FAKE_HOME/src/github.com/arbourd/dotfiles"
+    assert "$git_args" same_as "clone https://github.com/arbourd/dotfiles.git $target"
+    assert "$HOME/.local/bin/dot" is_link
+    assert "$(readlink "$HOME/.local/bin/dot")" same_as "$target/dot.sh"
 }
 
-@test 'clone pulls when target already exists' {
+@test 'init pulls and re-symlinks dot when target already exists' {
     local target="$FAKE_HOME/src/github.com/arbourd/dotfiles"
     mkdir -p "$target"
     getpath="$FAKE_HOME/src"
@@ -64,9 +67,45 @@
     local git_args
     git() { git_args="$*"; }
 
-    _clone > /dev/null
+    _init > /dev/null
 
     assert "$git_args" same_as "-C $target pull"
+    assert "$HOME/.local/bin/dot" is_link
+    assert "$(readlink "$HOME/.local/bin/dot")" same_as "$target/dot.sh"
+}
+
+@test 'update reports up to date when HEAD does not change' {
+    git() {
+        if [[ "$*" == *"rev-parse --short HEAD" ]]; then echo "abc1234"; return 0; fi
+        if [[ "$*" == *"pull --quiet" ]]; then return 0; fi
+        command git "$@"
+    }
+
+    run _update
+
+    assert $state equals 0
+    assert "$output" contains "abc1234"
+    assert "$output" contains "up to date"
+}
+
+@test 'update reports old and new hashes when HEAD changes' {
+    local flag=$(mktemp)
+    rm "$flag"
+    git() {
+        if [[ "$*" == *"pull --quiet" ]]; then touch "$flag"; return 0; fi
+        if [[ "$*" == *"rev-parse --short HEAD" ]]; then
+            if [[ -e "$flag" ]]; then echo "def5678"; else echo "abc1234"; fi
+            return 0
+        fi
+        command git "$@"
+    }
+
+    run _update
+
+    rm -f "$flag"
+    assert $state equals 0
+    assert "$output" contains "abc1234"
+    assert "$output" contains "def5678"
 }
 
 @test 'link creates dotfile symlinks' {
@@ -209,5 +248,19 @@
     unset GETPATH
     unset getpath
     source "$FAKE_HOME/dot.sh"
-    assert "$getpath" same_as "~/src"
+    assert "$getpath" same_as "$HOME/src"
+}
+
+@test 'init symlink target is absolute when getpath contains a literal tilde' {
+    GETPATH="~/src"
+    getpath="$GETPATH"
+    local target="$HOME/src/github.com/arbourd/dotfiles"
+
+    local git_args
+    git() { git_args="$*"; }
+
+    _init > /dev/null
+
+    assert "$HOME/.local/bin/dot" is_link
+    assert "$(readlink "$HOME/.local/bin/dot")" same_as "$target/dot.sh"
 }


### PR DESCRIPTION
`init` replaces clone and symlinks `dot` to the PATH via
~/.local/bin/dot. Adds `update` which pulls changes alone. Merges
`clean` into `link`.

Close #8